### PR TITLE
Mutilingual

### DIFF
--- a/configuration/commands.xml
+++ b/configuration/commands.xml
@@ -736,8 +736,9 @@ alt causes menu to be selected
                     <cfg:command name="setCollOrProcCitation"/>
                     <cfg:command name="setAuthorContactInfo"/>
                     <cfg:command name="setFramedType"/>
-                    <cfg:command name="setContentType"/>
+                    <!--MRL Swapped priority of type and contentType after adding contentType to object -->
                     <cfg:command name="setType"/>
+                    <cfg:command name="setContentType"/>
                     <cfg:command name="setGlossaryTerm"/>
                     <cfg:command name="setAnnotation"/>
                     <cfg:command name="setAnnotatedBibliographyType"/>

--- a/dtds/XLingPap.dtd
+++ b/dtds/XLingPap.dtd
@@ -415,6 +415,7 @@
 <!ELEMENT object (#PCDATA | object | abbrRef)*>
 <!ATTLIST object
     type IDREF #REQUIRED
+    contentType IDREF #IMPLIED
     xml:lang CDATA #IMPLIED
 >
 

--- a/dtds/XLingPap.dtd
+++ b/dtds/XLingPap.dtd
@@ -142,7 +142,7 @@
     xml:lang CDATA #REQUIRED
 >
 <!-- Front matter -->
-<!ELEMENT frontMatter (title, shortTitle?, subtitle?, ((author, affiliation*, emailAddress*) | authorContactInfo)+, shortAuthor?, presentedAt?, date?, version?, keywordsShownHere?, contents?, acknowledgements?, abstract?, preface*)>
+<!ELEMENT frontMatter (title, shortTitle?, subtitle?, ((author, affiliation*, emailAddress*) | authorContactInfo)+, shortAuthor?, presentedAt?, date?, version?, keywordsShownHere?, contents*, acknowledgements?, abstract?, preface*)>
 <!ELEMENT title (#PCDATA | %embedded;)*>
 <!ATTLIST title
     xml:lang CDATA #IMPLIED

--- a/transforms/XLingPap1.xsl
+++ b/transforms/XLingPap1.xsl
@@ -981,76 +981,86 @@
       LISTS
       =========================================================== -->
     <xsl:template match="ol">
-        <xsl:variable name="NestingLevel">
-            <xsl:choose>
-                <xsl:when test="ancestor::endnote">
-                    <xsl:value-of select="count(ancestor::ol[not(descendant::endnote)])"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="count(ancestor::ol)"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <xsl:element name="ol">
-            <xsl:attribute name="style">
-                <xsl:text>list-style-type:</xsl:text>
-                <xsl:variable name="sNumberFormat" select="@numberFormat"/>
-                <xsl:choose>
-                    <xsl:when test="string-length($sNumberFormat) &gt; 0">
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:variable name="NestingLevel">
+                    <xsl:choose>
+                        <xsl:when test="ancestor::endnote">
+                            <xsl:value-of select="count(ancestor::ol[not(descendant::endnote)])"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="count(ancestor::ol)"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:element name="ol">
+                    <xsl:attribute name="style">
+                        <xsl:text>list-style-type:</xsl:text>
+                        <xsl:variable name="sNumberFormat" select="@numberFormat"/>
                         <xsl:choose>
-                            <xsl:when test="$sNumberFormat='1'">
-                                <xsl:text>decimal</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='A'">
-                                <xsl:text>upper-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='a'">
-                                <xsl:text>lower-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='I'">
-                                <xsl:text>upper-roman</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='i'">
-                                <xsl:text>lower-roman</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='01'">
-                                <xsl:text>decimal-leading-zero</xsl:text>
+                            <xsl:when test="string-length($sNumberFormat) &gt; 0">
+                                <xsl:choose>
+                                    <xsl:when test="$sNumberFormat='1'">
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='A'">
+                                        <xsl:text>upper-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='a'">
+                                        <xsl:text>lower-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='I'">
+                                        <xsl:text>upper-roman</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='i'">
+                                        <xsl:text>lower-roman</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='01'">
+                                        <xsl:text>decimal-leading-zero</xsl:text>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:otherwise>
+                                </xsl:choose>
                             </xsl:when>
                             <xsl:otherwise>
-                                <xsl:text>decimal</xsl:text>
+                                <xsl:choose>
+                                    <xsl:when test="($NestingLevel mod 3)=0">
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="($NestingLevel mod 3)=1">
+                                        <xsl:text>lower-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="($NestingLevel mod 3)=2">
+                                        <xsl:text>lower-roman</xsl:text>
+                                    </xsl:when>
+                                </xsl:choose>
                             </xsl:otherwise>
                         </xsl:choose>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:choose>
-                            <xsl:when test="($NestingLevel mod 3)=0">
-                                <xsl:text>decimal</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="($NestingLevel mod 3)=1">
-                                <xsl:text>lower-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="($NestingLevel mod 3)=2">
-                                <xsl:text>lower-roman</xsl:text>
-                            </xsl:when>
-                        </xsl:choose>
-                    </xsl:otherwise>
-                </xsl:choose>
-                <xsl:text>; </xsl:text>
-                <xsl:call-template name="DoType"/>
-                <xsl:call-template name="OutputCssSpecial">
-                    <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:apply-templates/>
-        </xsl:element>
+                        <xsl:text>; </xsl:text>
+                        <xsl:call-template name="DoType"/>
+                        <xsl:call-template name="OutputCssSpecial">
+                            <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:apply-templates/>
+                </xsl:element>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="ul">
-        <ul>
-            <xsl:call-template name="OutputCssSpecial">
-                <xsl:with-param name="fDoStyleAttribute" select="'Y'"/>
-            </xsl:call-template>
-            <xsl:apply-templates/>
-        </ul>
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <ul>
+                    <xsl:call-template name="OutputCssSpecial">
+                        <xsl:with-param name="fDoStyleAttribute" select="'Y'"/>
+                    </xsl:call-template>
+                    <xsl:apply-templates/>
+                </ul>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="li">
         <li>
@@ -2639,63 +2649,78 @@
         FRAMEDUNIT
         =========================================================== -->
     <xsl:template match="framedUnit">
-        <div>
-            <xsl:attribute name="style">
-                <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
-                <xsl:text>background-color:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@backgroundcolor)"/>
-                    <xsl:with-param name="sDefaultValue" select="'white'"/>
-                </xsl:call-template>
-                <xsl:text>;margin-top:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spacebefore)"/>
-                    <xsl:with-param name="sDefaultValue" select="'.125in'"/>
-                </xsl:call-template>
-                <xsl:text>;margin-bottom:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spaceafter)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;margin-left:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-before)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;margin-right:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-after)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;padding-top:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innertopmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;padding-bottom:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerbottommargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;padding-left:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerleftmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;padding-right:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerrightmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;text-align:</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@align)"/>
-                    <xsl:with-param name="sDefaultValue">left</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>;border-width:.5pt;border-style:solid;border-color:black;</xsl:text>
-            </xsl:attribute>
-            <xsl:apply-templates/>
-        </div>
+        <xsl:choose>
+            <xsl:when test="count(p)=0"/>
+            <xsl:otherwise>
+                <div>
+                    <xsl:attribute name="style">
+                        <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
+                        <xsl:text>background-color:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@backgroundcolor)"/>
+                            <xsl:with-param name="sDefaultValue" select="'white'"/>
+                        </xsl:call-template>
+                        <xsl:text>;margin-top:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spacebefore)"/>
+                            <xsl:with-param name="sDefaultValue" select="'.125in'"/>
+                        </xsl:call-template>
+                        <xsl:text>;margin-bottom:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spaceafter)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;margin-left:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-before)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;margin-right:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-after)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;padding-top:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innertopmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;padding-bottom:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerbottommargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;padding-left:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerleftmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;padding-right:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerrightmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;text-align:</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@align)"/>
+                            <xsl:with-param name="sDefaultValue">left</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>;border-width:.5pt;border-style:solid;border-color:black;</xsl:text>
+                    </xsl:attribute>
+                    <xsl:apply-templates/>
+                </div>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <!-- ===========================================================
       IMG

--- a/transforms/XLingPapFO1.xsl
+++ b/transforms/XLingPapFO1.xsl
@@ -1367,10 +1367,20 @@
       LISTS
       =========================================================== -->
     <xsl:template match="ol">
-        <xsl:call-template name="DoOl"/>
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:call-template name="DoOl"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="ul">
-        <xsl:call-template name="DoUl"/>
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:call-template name="DoUl"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="li">
         <fo:list-item relative-align="baseline">

--- a/transforms/XLingPapFOCommon.xsl
+++ b/transforms/XLingPapFOCommon.xsl
@@ -154,73 +154,88 @@
         FRAMEDUNIT
         =========================================================== -->
     <xsl:template match="framedUnit">
-        <fo:block>
-            <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
-            <xsl:attribute name="background-color">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@backgroundcolor)"/>
-                    <xsl:with-param name="sDefaultValue" select="'white'"/>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="margin-top">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spacebefore)"/>
-                    <xsl:with-param name="sDefaultValue" select="'.125in'"/>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="margin-bottom">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spaceafter)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="margin-left">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-before)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="margin-right">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-after)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="padding-top">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innertopmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="padding-bottom">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerbottommargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="padding-left">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerleftmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="padding-right">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerrightmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="text-align">
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@align)"/>
-                    <xsl:with-param name="sDefaultValue">left</xsl:with-param>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:attribute name="border-width">.5pt</xsl:attribute>
-            <xsl:attribute name="border-style">solid</xsl:attribute>
-            <xsl:attribute name="border-color">black</xsl:attribute>
-            <xsl:apply-templates/>
-        </fo:block>
+        <xsl:choose>
+            <xsl:when test="count(p)=0"/>
+            <xsl:otherwise>
+                <fo:block>
+                    <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
+                    <xsl:attribute name="background-color">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@backgroundcolor)"/>
+                            <xsl:with-param name="sDefaultValue" select="'white'"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="margin-top">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spacebefore)"/>
+                            <xsl:with-param name="sDefaultValue" select="'.125in'"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="margin-bottom">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spaceafter)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="margin-left">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-before)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="margin-right">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-after)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="padding-top">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innertopmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="padding-bottom">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerbottommargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="padding-left">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerleftmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="padding-right">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerrightmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="text-align">
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@align)"/>
+                            <xsl:with-param name="sDefaultValue">left</xsl:with-param>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:attribute name="border-width">.5pt</xsl:attribute>
+                    <xsl:attribute name="border-style">solid</xsl:attribute>
+                    <xsl:attribute name="border-color">black</xsl:attribute>
+                    <xsl:apply-templates/>
+                </fo:block>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <!--
         ApplyTemplatesPerTextRefMode

--- a/transforms/XLingPapPublisherStylesheetFO.xsl
+++ b/transforms/XLingPapPublisherStylesheetFO.xsl
@@ -1575,10 +1575,20 @@
         LISTS
         =========================================================== -->
     <xsl:template match="ol">
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
         <xsl:call-template name="DoOl"/>
+        </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="ul">
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
         <xsl:call-template name="DoUl"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="li">
         <!-- insert a new line so we don't get everything all on one line -->

--- a/transforms/XLingPapPublisherStylesheetXHTML.xsl
+++ b/transforms/XLingPapPublisherStylesheetXHTML.xsl
@@ -2202,9 +2202,14 @@
         FRAMEDUNIT
         =========================================================== -->
     <xsl:template match="framedUnit">
-        <div class="framedType{@framedtype}">
-            <xsl:apply-templates/>
-        </div>
+        <xsl:choose>
+            <xsl:when test="count(p)=0"/>
+            <xsl:otherwise>
+                <div class="framedType{@framedtype}">
+                    <xsl:apply-templates/>
+                </div>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <!-- ===========================================================
         LANDSCAPE

--- a/transforms/XLingPapRemoveAnyContent.xsl
+++ b/transforms/XLingPapRemoveAnyContent.xsl
@@ -106,6 +106,9 @@
    <xsl:template match="ol">
       <xsl:call-template name="IgnoreOrCopyElement"/>
    </xsl:template>
+   <xsl:template match="object">
+      <xsl:call-template name="IgnoreOrCopyElement"/>
+   </xsl:template>
    <xsl:template match="p">
       <xsl:call-template name="IgnoreOrCopyElement"/>
    </xsl:template>

--- a/transforms/XLingPapXHTMLCommon.xsl
+++ b/transforms/XLingPapXHTMLCommon.xsl
@@ -98,80 +98,90 @@
         LISTS
         =========================================================== -->
     <xsl:template match="ol">
-        <xsl:variable name="NestingLevel">
-            <xsl:choose>
-                <xsl:when test="ancestor::endnote">
-                    <xsl:value-of select="count(ancestor::ol[not(descendant::endnote)])"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:value-of select="count(ancestor::ol)"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <ol>
-            <xsl:attribute name="style">
-                <xsl:text>list-style-type:</xsl:text>
-                <xsl:variable name="sNumberFormat" select="@numberFormat"/>
-                <xsl:choose>
-                    <xsl:when test="string-length($sNumberFormat) &gt; 0">
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:variable name="NestingLevel">
+                    <xsl:choose>
+                        <xsl:when test="ancestor::endnote">
+                            <xsl:value-of select="count(ancestor::ol[not(descendant::endnote)])"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="count(ancestor::ol)"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <ol>
+                    <xsl:attribute name="style">
+                        <xsl:text>list-style-type:</xsl:text>
+                        <xsl:variable name="sNumberFormat" select="@numberFormat"/>
                         <xsl:choose>
-                            <xsl:when test="$sNumberFormat='1'">
-                                <xsl:text>decimal</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='A'">
-                                <xsl:text>upper-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='a'">
-                                <xsl:text>lower-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='I'">
-                                <xsl:text>upper-roman</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='i'">
-                                <xsl:text>lower-roman</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="$sNumberFormat='01'">
-                                <xsl:text>decimal-leading-zero</xsl:text>
+                            <xsl:when test="string-length($sNumberFormat) &gt; 0">
+                                <xsl:choose>
+                                    <xsl:when test="$sNumberFormat='1'">
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='A'">
+                                        <xsl:text>upper-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='a'">
+                                        <xsl:text>lower-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='I'">
+                                        <xsl:text>upper-roman</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='i'">
+                                        <xsl:text>lower-roman</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="$sNumberFormat='01'">
+                                        <xsl:text>decimal-leading-zero</xsl:text>
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:otherwise>
+                                </xsl:choose>
                             </xsl:when>
                             <xsl:otherwise>
-                                <xsl:text>decimal</xsl:text>
+                                <xsl:choose>
+                                    <xsl:when test="($NestingLevel mod 3)=0">
+                                        <xsl:text>decimal</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="($NestingLevel mod 3)=1">
+                                        <xsl:text>lower-alpha</xsl:text>
+                                    </xsl:when>
+                                    <xsl:when test="($NestingLevel mod 3)=2">
+                                        <xsl:text>lower-roman</xsl:text>
+                                    </xsl:when>
+                                </xsl:choose>
                             </xsl:otherwise>
                         </xsl:choose>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:choose>
-                            <xsl:when test="($NestingLevel mod 3)=0">
-                                <xsl:text>decimal</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="($NestingLevel mod 3)=1">
-                                <xsl:text>lower-alpha</xsl:text>
-                            </xsl:when>
-                            <xsl:when test="($NestingLevel mod 3)=2">
-                                <xsl:text>lower-roman</xsl:text>
-                            </xsl:when>
-                        </xsl:choose>
-                    </xsl:otherwise>
-                </xsl:choose>
-                <xsl:text>; </xsl:text>
-                <xsl:call-template name="DoType"/>
-                <xsl:call-template name="OutputCssSpecial">
-                    <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:apply-templates/>
-        </ol>
+                        <xsl:text>; </xsl:text>
+                        <xsl:call-template name="DoType"/>
+                        <xsl:call-template name="OutputCssSpecial">
+                            <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:apply-templates/>
+                </ol>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="ul">
-        <ul>
-            <xsl:attribute name="style">
-                <xsl:text>list-style-type:disc; </xsl:text>
-                <xsl:call-template name="DoType"/>
-                <xsl:call-template name="OutputCssSpecial">
-                    <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
-                </xsl:call-template>
-            </xsl:attribute>
-            <xsl:apply-templates/>
-        </ul>
+        <xsl:choose>
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <ul>
+                    <xsl:attribute name="style">
+                        <xsl:text>list-style-type:disc; </xsl:text>
+                        <xsl:call-template name="DoType"/>
+                        <xsl:call-template name="OutputCssSpecial">
+                            <xsl:with-param name="fDoStyleAttribute" select="'N'"/>
+                        </xsl:call-template>
+                    </xsl:attribute>
+                    <xsl:apply-templates/>
+                </ul>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <xsl:template match="li">
         <li>

--- a/transforms/XLingPapXeLaTeXCommon.xsl
+++ b/transforms/XLingPapXeLaTeXCommon.xsl
@@ -529,99 +529,106 @@
       LISTS
       =========================================================== -->
     <xsl:template match="ol">
-        <xsl:variable name="sThisItemWidth">
-            <xsl:call-template name="GetItemWidth"/>
-        </xsl:variable>
         <xsl:choose>
-            <xsl:when test="count(ancestor::ul | ancestor::ol) = 0 or parent::endnote">
-                <xsl:if test="parent::definition">
-                    <xsl:call-template name="DoTypeEnd">
-                        <xsl:with-param name="type" select="../@type"/>
-                    </xsl:call-template>
-                </xsl:if>
-                <tex:group>
-                    <tex:spec cat="esc"/>
-                    <xsl:text>parskip .5pt plus 1pt minus 1pt
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:variable name="sThisItemWidth">
+                    <xsl:call-template name="GetItemWidth"/>
+                </xsl:variable>
+                <xsl:choose>
+                    <xsl:when test="count(ancestor::ul | ancestor::ol) = 0 or parent::endnote">
+                        <xsl:if test="parent::definition">
+                            <xsl:call-template name="DoTypeEnd">
+                                <xsl:with-param name="type" select="../@type"/>
+                            </xsl:call-template>
+                        </xsl:if>
+                        <tex:group>
+                            <tex:spec cat="esc"/>
+                            <xsl:text>parskip .5pt plus 1pt minus 1pt
                     </xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="parent::definition and ancestor::p">
-                            <xsl:text>&#x0a;</xsl:text>
-                        </xsl:when>
-                        <xsl:when test="parent::chart/preceding-sibling::*[1][name()='exampleHeading']">
-                            <!-- do nothing -->
-                        </xsl:when>
-                        <xsl:otherwise>
+                            <xsl:choose>
+                                <xsl:when test="parent::definition and ancestor::p">
+                                    <xsl:text>&#x0a;</xsl:text>
+                                </xsl:when>
+                                <xsl:when
+                                    test="parent::chart/preceding-sibling::*[1][name()='exampleHeading']">
+                                    <!-- do nothing -->
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <tex:cmd name="vspace" nl1="1" nl2="1">
+                                        <tex:parm>
+                                            <xsl:call-template name="VerticalSkipAroundList"/>
+                                        </tex:parm>
+                                    </tex:cmd>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            <xsl:if test="parent::definition">
+                                <xsl:call-template name="DoType">
+                                    <xsl:with-param name="type" select="../@type"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:if test="string-length(@numberFormat) &gt; 0">
+                                <xsl:call-template name="SetTeXCommand">
+                                    <xsl:with-param name="sTeXCommand" select="'settowidth'"/>
+                                    <xsl:with-param name="sCommandToSet">
+                                        <xsl:call-template name="GetDynamicListItemName"/>
+                                    </xsl:with-param>
+                                    <xsl:with-param name="sValue">
+                                        <xsl:call-template name="GetListItemWidthPattern">
+                                            <xsl:with-param name="sNumberFormat"
+                                                select="@numberFormat"/>
+                                        </xsl:call-template>
+                                        <xsl:text>.</xsl:text>
+                                        <tex:spec cat="esc"/>
+                                        <xsl:text>&#x20;</xsl:text>
+                                    </xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:apply-templates>
+                                <xsl:with-param name="sListItemWidth">
+                                    <tex:spec cat="esc"/>
+                                    <xsl:value-of select="$sThisItemWidth"/>
+                                </xsl:with-param>
+                                <xsl:with-param name="sListItemIndent">
+                                    <xsl:choose>
+                                        <xsl:when test="ancestor::example">
+                                            <tex:spec cat="esc"/>
+                                            <xsl:text>XLingPaperlistinexampleindent</xsl:text>
+                                        </xsl:when>
+                                        <xsl:when test="$sListInitialHorizontalOffset!='0pt'">
+                                            <xsl:value-of select="$sListInitialHorizontalOffset"/>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <!--<tex:spec cat="esc"/>
+                                    <xsl:value-of select="$sThisItemWidth"/> default should be paragraph indent -->
+                                            <tex:cmd name="parindent"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:with-param>
+                            </xsl:apply-templates>
+                            <xsl:if test="parent::definition">
+                                <xsl:call-template name="DoTypeEnd">
+                                    <xsl:with-param name="type" select="../@type"/>
+                                </xsl:call-template>
+                            </xsl:if>
                             <tex:cmd name="vspace" nl1="1" nl2="1">
                                 <tex:parm>
                                     <xsl:call-template name="VerticalSkipAroundList"/>
                                 </tex:parm>
                             </tex:cmd>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                    <xsl:if test="parent::definition">
-                        <xsl:call-template name="DoType">
-                            <xsl:with-param name="type" select="../@type"/>
+                        </tex:group>
+                        <xsl:if test="parent::definition">
+                            <xsl:call-template name="DoType">
+                                <xsl:with-param name="type" select="../@type"/>
+                            </xsl:call-template>
+                        </xsl:if>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="HandleEmbeddedListItem">
+                            <xsl:with-param name="sThisItemWidth" select="$sThisItemWidth"/>
                         </xsl:call-template>
-                    </xsl:if>
-                    <xsl:if test="string-length(@numberFormat) &gt; 0">
-                        <xsl:call-template name="SetTeXCommand">
-                            <xsl:with-param name="sTeXCommand" select="'settowidth'"/>
-                            <xsl:with-param name="sCommandToSet">
-                                <xsl:call-template name="GetDynamicListItemName"/>
-                            </xsl:with-param>
-                            <xsl:with-param name="sValue">
-                                <xsl:call-template name="GetListItemWidthPattern">
-                                    <xsl:with-param name="sNumberFormat" select="@numberFormat"/>
-                                </xsl:call-template>
-                                <xsl:text>.</xsl:text>
-                                <tex:spec cat="esc"/>
-                                <xsl:text>&#x20;</xsl:text>
-                            </xsl:with-param>
-                        </xsl:call-template>
-                    </xsl:if>
-                    <xsl:apply-templates>
-                        <xsl:with-param name="sListItemWidth">
-                            <tex:spec cat="esc"/>
-                            <xsl:value-of select="$sThisItemWidth"/>
-                        </xsl:with-param>
-                        <xsl:with-param name="sListItemIndent">
-                            <xsl:choose>
-                                <xsl:when test="ancestor::example">
-                                    <tex:spec cat="esc"/>
-                                    <xsl:text>XLingPaperlistinexampleindent</xsl:text>
-                                </xsl:when>
-                                <xsl:when test="$sListInitialHorizontalOffset!='0pt'">
-                                    <xsl:value-of select="$sListInitialHorizontalOffset"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <!--<tex:spec cat="esc"/>
-                                    <xsl:value-of select="$sThisItemWidth"/> default should be paragraph indent -->
-                                    <tex:cmd name="parindent"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:with-param>
-                    </xsl:apply-templates>
-                    <xsl:if test="parent::definition">
-                        <xsl:call-template name="DoTypeEnd">
-                            <xsl:with-param name="type" select="../@type"/>
-                        </xsl:call-template>
-                    </xsl:if>
-                    <tex:cmd name="vspace" nl1="1" nl2="1">
-                        <tex:parm>
-                            <xsl:call-template name="VerticalSkipAroundList"/>
-                        </tex:parm>
-                    </tex:cmd>
-                </tex:group>
-                <xsl:if test="parent::definition">
-                    <xsl:call-template name="DoType">
-                        <xsl:with-param name="type" select="../@type"/>
-                    </xsl:call-template>
-                </xsl:if>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:call-template name="HandleEmbeddedListItem">
-                    <xsl:with-param name="sThisItemWidth" select="$sThisItemWidth"/>
-                </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
@@ -863,75 +870,82 @@
     </xsl:template>
     <xsl:template match="ul">
         <xsl:choose>
-            <xsl:when test="count(ancestor::ul | ancestor::ol) = 0 or parent::endnote">
-                <xsl:if test="parent::definition">
-                    <xsl:call-template name="DoTypeEnd">
-                        <xsl:with-param name="type" select="../@type"/>
-                    </xsl:call-template>
-                </xsl:if>
-                <tex:group>
-                    <tex:spec cat="esc"/>
-                    <xsl:text>parskip .5pt plus 1pt minus 1pt
+            <xsl:when test="count(li)=0"/>
+            <xsl:otherwise>
+                <xsl:choose>
+                    <xsl:when test="count(ancestor::ul | ancestor::ol) = 0 or parent::endnote">
+                        <xsl:if test="parent::definition">
+                            <xsl:call-template name="DoTypeEnd">
+                                <xsl:with-param name="type" select="../@type"/>
+                            </xsl:call-template>
+                        </xsl:if>
+                        <tex:group>
+                            <tex:spec cat="esc"/>
+                            <xsl:text>parskip .5pt plus 1pt minus 1pt
 </xsl:text>
-                    <xsl:choose>
-                        <xsl:when test="parent::definition and ancestor::p">
-                            <xsl:text>&#x0a;</xsl:text>
-                        </xsl:when>
-                        <xsl:when test="parent::chart/preceding-sibling::*[1][name()='exampleHeading']">
-                            <!-- do nothing -->
-                        </xsl:when>
-                        <xsl:otherwise>
+                            <xsl:choose>
+                                <xsl:when test="parent::definition and ancestor::p">
+                                    <xsl:text>&#x0a;</xsl:text>
+                                </xsl:when>
+                                <xsl:when
+                                    test="parent::chart/preceding-sibling::*[1][name()='exampleHeading']">
+                                    <!-- do nothing -->
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <tex:cmd name="vspace" nl1="1" nl2="1">
+                                        <tex:parm>
+                                            <xsl:call-template name="VerticalSkipAroundList"/>
+                                        </tex:parm>
+                                    </tex:cmd>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            <xsl:if test="parent::definition">
+                                <xsl:call-template name="DoType">
+                                    <xsl:with-param name="type" select="../@type"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                            <xsl:apply-templates>
+                                <xsl:with-param name="sListItemIndent">
+                                    <xsl:choose>
+                                        <xsl:when test="ancestor::example">
+                                            <tex:spec cat="esc"/>
+                                            <xsl:text>XLingPaperlistinexampleindent</xsl:text>
+                                        </xsl:when>
+                                        <xsl:when test="$sListInitialHorizontalOffset!='0pt'">
+                                            <xsl:value-of select="$sListInitialHorizontalOffset"/>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <!--<tex:spec cat="esc"/>
+                                        <xsl:text>XLingPaperbulletlistitemwidth</xsl:text> default should be paragraph indent -->
+                                            <tex:cmd name="parindent"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </xsl:with-param>
+                            </xsl:apply-templates>
+                            <xsl:if test="parent::definition">
+                                <xsl:call-template name="DoTypeEnd">
+                                    <xsl:with-param name="type" select="../@type"/>
+                                </xsl:call-template>
+                            </xsl:if>
                             <tex:cmd name="vspace" nl1="1" nl2="1">
                                 <tex:parm>
                                     <xsl:call-template name="VerticalSkipAroundList"/>
                                 </tex:parm>
                             </tex:cmd>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                    <xsl:if test="parent::definition">
-                        <xsl:call-template name="DoType">
-                            <xsl:with-param name="type" select="../@type"/>
+                            <xsl:if test="parent::definition">
+                                <xsl:call-template name="DoType">
+                                    <xsl:with-param name="type" select="../@type"/>
+                                </xsl:call-template>
+                            </xsl:if>
+                        </tex:group>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:call-template name="HandleEmbeddedListItem">
+                            <xsl:with-param name="sThisItemWidth"
+                                select="'XLingPaperbulletlistitemwidth'"/>
                         </xsl:call-template>
-                    </xsl:if>
-                    <xsl:apply-templates>
-                        <xsl:with-param name="sListItemIndent">
-                            <xsl:choose>
-                                <xsl:when test="ancestor::example">
-                                    <tex:spec cat="esc"/>
-                                    <xsl:text>XLingPaperlistinexampleindent</xsl:text>
-                                </xsl:when>
-                                <xsl:when test="$sListInitialHorizontalOffset!='0pt'">
-                                    <xsl:value-of select="$sListInitialHorizontalOffset"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <!--<tex:spec cat="esc"/>
-                                        <xsl:text>XLingPaperbulletlistitemwidth</xsl:text> default should be paragraph indent -->
-                                    <tex:cmd name="parindent"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                        </xsl:with-param>
-                    </xsl:apply-templates>
-                    <xsl:if test="parent::definition">
-                        <xsl:call-template name="DoTypeEnd">
-                            <xsl:with-param name="type" select="../@type"/>
-                        </xsl:call-template>
-                    </xsl:if>
-                    <tex:cmd name="vspace" nl1="1" nl2="1">
-                        <tex:parm>
-                            <xsl:call-template name="VerticalSkipAroundList"/>
-                        </tex:parm>
-                    </tex:cmd>
-                    <xsl:if test="parent::definition">
-                        <xsl:call-template name="DoType">
-                            <xsl:with-param name="type" select="../@type"/>
-                        </xsl:call-template>
-                    </xsl:if>
-                </tex:group>
-            </xsl:when>
-            <xsl:otherwise>
-                <xsl:call-template name="HandleEmbeddedListItem">
-                    <xsl:with-param name="sThisItemWidth" select="'XLingPaperbulletlistitemwidth'"/>
-                </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
@@ -2558,69 +2572,84 @@
         FRAMEDUNIT
         =========================================================== -->
     <xsl:template match="framedUnit">
-        <tex:env name="mdframed">
-            <tex:opt>
-                <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
-                <xsl:text>backgroundcolor=</xsl:text>
-                <xsl:variable name="sColor" select="normalize-space($framedtype/@backgroundcolor)"/>
-                <xsl:choose>
-                    <xsl:when test="string-length($sColor) &gt; 0">
-                        <xsl:call-template name="GetFramedTypeBackgroundColorName">
-                            <xsl:with-param name="sId" select="@framedtype"/>
+        <xsl:choose>
+            <xsl:when test="count(p)=0"/>
+            <xsl:otherwise>
+                <tex:env name="mdframed">
+                    <tex:opt>
+                        <xsl:variable name="framedtype" select="key('FramedTypeID',@framedtype)"/>
+                        <xsl:text>backgroundcolor=</xsl:text>
+                        <xsl:variable name="sColor"
+                            select="normalize-space($framedtype/@backgroundcolor)"/>
+                        <xsl:choose>
+                            <xsl:when test="string-length($sColor) &gt; 0">
+                                <xsl:call-template name="GetFramedTypeBackgroundColorName">
+                                    <xsl:with-param name="sId" select="@framedtype"/>
+                                </xsl:call-template>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:text>white</xsl:text>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                        <xsl:text>,skipabove=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spacebefore)"/>
+                            <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
                         </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:text>white</xsl:text>
-                    </xsl:otherwise>
-                </xsl:choose>
-                <xsl:text>,skipabove=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spacebefore)"/>
-                    <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
-                </xsl:call-template>
-                <xsl:text>,skipbelow=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@spaceafter)"/>
-                    <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
-                </xsl:call-template>
-                <xsl:text>,innermargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-before)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>,outermargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@indent-after)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>,innertopmargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innertopmargin)"/>
-                    <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
-                </xsl:call-template>
-                <xsl:text>,innerbottommargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerbottommargin)"/>
-                    <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
-                </xsl:call-template>
-                <xsl:text>,innerleftmargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerleftmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>,innerrightmargin=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@innerrightmargin)"/>
-                    <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
-                </xsl:call-template>
-                <xsl:text>,align=</xsl:text>
-                <xsl:call-template name="SetFramedTypeItem">
-                    <xsl:with-param name="sAttributeValue" select="normalize-space($framedtype/@align)"/>
-                    <xsl:with-param name="sDefaultValue">left</xsl:with-param>
-                </xsl:call-template>
-            </tex:opt>
-            <xsl:apply-templates/>
-        </tex:env>
+                        <xsl:text>,skipbelow=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@spaceafter)"/>
+                            <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
+                        </xsl:call-template>
+                        <xsl:text>,innermargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-before)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>,outermargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@indent-after)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>,innertopmargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innertopmargin)"/>
+                            <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
+                        </xsl:call-template>
+                        <xsl:text>,innerbottommargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerbottommargin)"/>
+                            <xsl:with-param name="bUseBaselineskipAsDefault" select="'Y'"/>
+                        </xsl:call-template>
+                        <xsl:text>,innerleftmargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerleftmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>,innerrightmargin=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@innerrightmargin)"/>
+                            <xsl:with-param name="sDefaultValue">.125in</xsl:with-param>
+                        </xsl:call-template>
+                        <xsl:text>,align=</xsl:text>
+                        <xsl:call-template name="SetFramedTypeItem">
+                            <xsl:with-param name="sAttributeValue"
+                                select="normalize-space($framedtype/@align)"/>
+                            <xsl:with-param name="sDefaultValue">left</xsl:with-param>
+                        </xsl:call-template>
+                    </tex:opt>
+                    <xsl:apply-templates/>
+                </tex:env>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     <!-- ===========================================================
         LANDSCAPE


### PR DESCRIPTION
These 2 commits lead the way to making truly multilingual documents, as most fields can contain objects. Objects will now have a contentType attribute, and thus items can be filtered by Content Control.
As a result:
```
<secTitle>
<object contentType="en" type="t-en">OD : Organising your desktop</object>
<object contentType="fr" type="t-fr">OB : Organisation du bureau</object>
</secTitle>
```
Can be exported as "OD : Organising your desktop" or "OB : Organisation du bureau" and the Table of contents and all references will be properly updated. 

Test files:

https://www.dropbox.com/s/vwjoit8r78db4q9/CourseModel.xml?dl=0
https://www.dropbox.com/s/pkyk40dhxwor8ab/SILInternationalBookletStylesheet.xml?dl=0