### PR TITLE
Add/implement "lineBefore" option before sections.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.classpath
+*~
+javasrc/XLingPapExtensions/bin
+javasrc/XLingPapExtensions/XLingPap.jar
+
+

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ A way to author and archive linguistic papers or books in the Third Wave
 
 These are configuration files for the XMLmind XML Editor (http://www.xmlmind.com/xmleditor/), also known as XXE.  This editor provides an excellent way to hide the complexities of XML while editing.
 
-Unfortunately, sometimes newer versions of XXE break older configuation mechanisms.  For this reason, we have two main branches: **XXE5.3** and **XXE7.2**.  The configuration files for XXE version 5.3.0 are not compatible with the ones for XXE versionn 7.2.0.  The main files which differ betweeen the two are:
+Unfortunately, sometimes newer versions of XXE break older configuation mechanisms.  For this reason, we have two main branches: **XXE5.3** and **XXE7.3**.  The configuration files for XXE version 5.3.0 are not compatible with the ones for XXE versionn 7.3.0.  The main files which differ betweeen the two are:
 * configuration/commands.xml
 * configuration/menus.xml
 * configuration/menusLonger.xml
 * configuration/menus.Shorter.xml
-* css/XLingPap.css (and resource files in **XXE7.2**)
-* externalPackages (**XXE7.2** has JColorChooser which is no longer in Java 8 by default)
-* javasrc (**XXE5.3** is for Java 6 and **XXE7.2** is for Java 8, plus some other differences)
+* css/XLingPap.css (and resource files in **XXE7.3**)
+* externalPackages (**XXE7.3** has JColorChooser which is no longer in Java 8 by default)
+* javasrc (**XXE5.3** is for Java 6 and **XXE7.3** is for Java 8, plus some other differences)
 * XLingPap.jar
 * XLingPap.xxe
 

--- a/dtds/XLingPapAttributeEntities.dtd
+++ b/dtds/XLingPapAttributeEntities.dtd
@@ -72,6 +72,7 @@
 <!ENTITY % titleformatinfo "
      usetitleinheader (yes | no) 'yes'
      useemptyheaderfooter (yes | no) 'no'
+     linebefore (yes | no) 'no'
      %pagebreakformatinfo;
      %frontmatterformatinfo;"
      >

--- a/transforms/XLingPapPublisherStylesheetFO.xsl
+++ b/transforms/XLingPapPublisherStylesheetFO.xsl
@@ -5837,6 +5837,11 @@ not using
         <xsl:param name="formatTitleLayoutInfo"/>
         <xsl:param name="numberLayoutInfo"/>
         <xsl:param name="layoutInfo"/>
+        <xsl:if test="$layoutInfo/sectionTitleLayout/@linebefore='yes'">
+            <fo:block keep-with-next.within-page="always">
+                <fo:leader leader-pattern="rule" leader-length="100%" rule-style="solid" rule-thickness="1pt"/>
+            </fo:block>
+        </xsl:if>
         <fo:block id="{@id}" keep-with-next.within-page="always">
             <xsl:call-template name="DoTitleFormatInfo">
                 <xsl:with-param name="layoutInfo" select="$formatTitleLayoutInfo"/>

--- a/transforms/XLingPapPublisherStylesheetXeLaTeX.xsl
+++ b/transforms/XLingPapPublisherStylesheetXeLaTeX.xsl
@@ -5356,6 +5356,9 @@
             <xsl:if test="contains(key('TypeID',@type)/@XeLaTeXSpecial,'pagebreak')">
                 <tex:cmd name="pagebreak" gr="0" nl2="0"/>
             </xsl:if>
+            <xsl:if test="$layoutInfo/sectionTitleLayout/@linebefore='yes'">
+                <tex:cmd name="noindent" nl2="0"/><tex:cmd name="hrulefill" nl2="0"/><tex:cmd name="linebreak" nl2="0"/>
+            </xsl:if>
             <!--            <xsl:call-template name="DoTitleNeedsSpace"/> Now do this in DoTitleFormatInfo-->
             <xsl:variable name="sTextTransform" select="$formatTitleLayoutInfo/@text-transform"/>
             <xsl:if test="$sTextTransform='uppercase' or $sTextTransform='lowercase'">


### PR DESCRIPTION
Added lineBefore option to Attribute Entities and appropriate response in XeLaTeX/FO Publisher transforms. XHTML has this feature by default, so I didn't touch it.

XeLaTeX and Xep show full-width line. ODT/Word2003 show half-width line. 

This works in output, but I'm not 100% sure if I put lineBefore in the right inherited section. Please check the location of the lineBefore in Attribute entities and adjust accordingly if there is a better place.

Let me know if I need to implement it in XLingPap.css.